### PR TITLE
Default week selector to current week with visual indication

### DIFF
--- a/frontend/src/components/schedule/ScheduleFilters.tsx
+++ b/frontend/src/components/schedule/ScheduleFilters.tsx
@@ -298,10 +298,17 @@ const ScheduleFilters: React.FC<ScheduleFiltersProps> = ({
                 sx={{ borderColor: 'rgba(255,255,255,0.3)' }}
               />
               <Chip
-                label={filters.week ? `Week ${filters.week}` : 'Current Week'}
+                label={filters.week ? 
+                  `Week ${filters.week}${filters.week === weekNavigation.currentWeekNumber ? ' (Current)' : ''}` : 
+                  'Current Week'
+                }
                 size="small"
                 variant="outlined"
-                sx={{ borderColor: 'rgba(255,255,255,0.3)' }}
+                sx={{ 
+                  borderColor: filters.week === weekNavigation.currentWeekNumber ? 'primary.main' : 'rgba(255,255,255,0.3)',
+                  color: filters.week === weekNavigation.currentWeekNumber ? 'primary.main' : 'inherit',
+                  fontWeight: filters.week === weekNavigation.currentWeekNumber ? 600 : 400,
+                }}
               />
               <Chip
                 label={filters.teamView === 'selected' 

--- a/frontend/src/components/schedule/WeekNavigation.tsx
+++ b/frontend/src/components/schedule/WeekNavigation.tsx
@@ -44,17 +44,15 @@ const WeekNavigation: React.FC<WeekNavigationProps> = ({
 }) => {
   const handleWeekSelect = (event: SelectChangeEvent<string>) => {
     const selectedValue = event.target.value;
-    if (selectedValue === 'current') {
-      onWeekSelect(null); // null means current week
-    } else {
-      const weekOption = weekOptions.find(w => w.value === selectedValue);
-      if (weekOption) {
-        onWeekSelect(weekOption.weekNumber);
-      }
+    const weekOption = weekOptions.find(w => w.value === selectedValue);
+    if (weekOption) {
+      onWeekSelect(weekOption.weekNumber);
     }
   };
 
-  const selectedWeekOption = weekOptions.find(w => w.weekNumber === currentWeek);
+  // Find the selected week option, defaulting to current week if no selection
+  const selectedWeekOption = weekOptions.find(w => w.weekNumber === currentWeek) ||
+    weekOptions.find(w => w.isCurrentWeek);
 
   return (
     <Box sx={{ flex: 1, minWidth: 200 }}>
@@ -76,7 +74,7 @@ const WeekNavigation: React.FC<WeekNavigationProps> = ({
         
         <FormControl sx={{ minWidth: 120, flex: 1 }}>
           <Select
-            value={currentWeek === null ? 'current' : selectedWeekOption?.value || 'current'}
+            value={selectedWeekOption?.value || ''}
             onChange={handleWeekSelect}
             size="small"
             disabled={loading}
@@ -90,16 +88,27 @@ const WeekNavigation: React.FC<WeekNavigationProps> = ({
               },
             }}
           >
-            <MenuItem value="current">
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <CalendarIcon sx={{ fontSize: 16 }} />
-                Current Week
-              </Box>
-            </MenuItem>
             {weekOptions.map((week) => (
               <MenuItem key={week.value} value={week.value}>
-                {week.label}
-                {week.isCurrentWeek && ' (Current)'}
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%' }}>
+                  {week.isCurrentWeek && (
+                    <CalendarIcon sx={{ 
+                      fontSize: 16, 
+                      color: 'primary.main',
+                      mr: 0.5 
+                    }} />
+                  )}
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      fontWeight: week.isCurrentWeek ? 600 : 400,
+                      color: week.isCurrentWeek ? 'primary.main' : 'inherit',
+                    }}
+                  >
+                    {week.label}
+                    {week.isCurrentWeek && ' (Current Week)'}
+                  </Typography>
+                </Box>
               </MenuItem>
             ))}
           </Select>

--- a/frontend/src/pages/SchedulePage.tsx
+++ b/frontend/src/pages/SchedulePage.tsx
@@ -49,6 +49,9 @@ const SchedulePage: React.FC = () => {
     conference: null,
   });
 
+  // Track if we've initialized from current week data
+  const [hasInitializedFromCurrentWeek, setHasInitializedFromCurrentWeek] = useState(false);
+
   // Fetch schedule data using the custom hook
   const {
     data: games,
@@ -101,6 +104,17 @@ const SchedulePage: React.FC = () => {
       conference: conferenceParam === 'All Conferences' ? null : conferenceParam,
     });
   }, [searchParams]);
+
+  // Initialize to current week when current week data is available and no URL params specify a week
+  useEffect(() => {
+    if (currentWeek && !hasInitializedFromCurrentWeek && !searchParams.get('week')) {
+      setFilters(prev => ({
+        ...prev,
+        week: currentWeek.currentWeek,
+      }));
+      setHasInitializedFromCurrentWeek(true);
+    }
+  }, [currentWeek, hasInitializedFromCurrentWeek, searchParams]);
 
   const handleFiltersChange = (newFilters: ScheduleFiltersState) => {
     setFilters(newFilters);


### PR DESCRIPTION

  Week Selector Auto-Default to Current Week

  Summary

  Improves the week selector user experience by automatically defaulting to the current week
  and providing clear visual indication, eliminating the need for users to manually select
  "current week" from a dropdown.

  Changes Made

  - Removed separate "Current Week" option from dropdown menu
  - Auto-defaults to current week when page loads without URL parameters
  - Enhanced visual indication for current week with:
    - Calendar icon
    - Bold text styling
    - Primary color highlighting
    - "(Current Week)" annotation
  - Updated active filters chip to show current week status
  - Maintained backward compatibility with existing URL parameter handling

  Acceptance Criteria Met

  - AC1: Week dropdown defaults to current week number on page load
  - AC2: No separate "Current Week" option exists in dropdown
  - AC3: Current week is visually distinct with clear indicators

  Technical Implementation

  - Modified WeekNavigation.tsx to remove separate current week option and add visual styling
  - Updated SchedulePage.tsx to auto-initialize current week on load
  - Enhanced ScheduleFilters.tsx active filters display
  - Preserved existing week calculation logic from backend API

  Testing

  - TypeScript compilation passes
  - Build succeeds without errors
  - Existing functionality preserved
  - URL parameter handling maintains backward compatibility